### PR TITLE
[WIP] V2 spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./test.js",
   "dependencies": {
-    "mapnik" : "https://github.com/mapnik/node-mapnik/tarball/master",
+    "mapnik" : "https://github.com/mapnik/node-mapnik/tarball/v2_spec",
     "srs":"~1.1.0",
     "gdal":"~0.8.0",
     "preprocessorcerer": "https://github.com/mapbox/preprocessorcerer/tarball/master",

--- a/package.json
+++ b/package.json
@@ -18,20 +18,20 @@
     "mapnik-reference" : "https://github.com/mapnik/mapnik-reference/tarball/master",
     "blend" : "https://github.com/mapbox/node-blend/tarball/master",
     "abaculus" : "https://github.com/mapbox/abaculus/tarball/master",
-    "tilelive-bridge": "https://github.com/mapbox/tilelive-bridge/tarball/master",
+    "tilelive-bridge": "https://github.com/mapbox/tilelive-bridge/tarball/mapnik-v2_spec",
     "tilelive-mapnik": "https://github.com/mapbox/tilelive-mapnik/tarball/master",
     "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/master",
     "vector-tile-query": "https://github.com/mapbox/vector-tile-query/tarball/update-deps",
     "assert-http": "https://github.com/mapbox/assert-http/tarball/master",
     "landspeed": "https://github.com/mapbox/landspeed.js/tarball/master",
-    "tilelive-vector": "https://github.com/mapbox/tilelive-vector/tarball/master",
+    "tilelive-vector": "https://github.com/mapbox/tilelive-vector/tarball/mapnik-v2_spec",
     "mapnik-pool": "https://github.com/mapbox/mapnik-pool/tarball/master",
     "geojson-mapnikify": "https://github.com/mapbox/geojson-mapnikify/tarball/master",
     "tilelive-overlay": "https://github.com/mapbox/tilelive-overlay/tarball/master",
-    "tilelive-omnivore": "https://github.com/mapbox/tilelive-omnivore/tarball/master",
+    "tilelive-omnivore": "https://github.com/mapbox/tilelive-omnivore/tarball/mapnik-v2_spec",
     "raster-tile-query": "https://github.com/mapbox/raster-tile-query/tarball/master",
     "spritezero": "https://github.com/mapbox/spritezero/tarball/master",
-    "mapbox-upload-validate": "https://github.com/mapbox/mapbox-upload-validate/tarball/update-deps"
+    "mapbox-upload-validate": "https://github.com/mapbox/mapbox-upload-validate/tarball/mapnik-v2_spec"
   }, 
   "devDependencies": {
     "mocha": "1.x"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tilelive-bridge": "https://github.com/mapbox/tilelive-bridge/tarball/master",
     "tilelive-mapnik": "https://github.com/mapbox/tilelive-mapnik/tarball/master",
     "mapnik-omnivore": "https://github.com/mapbox/mapnik-omnivore/tarball/master",
-    "vector-tile-query": "https://github.com/mapbox/vector-tile-query/tarball/master",
+    "vector-tile-query": "https://github.com/mapbox/vector-tile-query/tarball/update-deps",
     "assert-http": "https://github.com/mapbox/assert-http/tarball/master",
     "landspeed": "https://github.com/mapbox/landspeed.js/tarball/master",
     "tilelive-vector": "https://github.com/mapbox/tilelive-vector/tarball/master",
@@ -31,7 +31,7 @@
     "tilelive-omnivore": "https://github.com/mapbox/tilelive-omnivore/tarball/master",
     "raster-tile-query": "https://github.com/mapbox/raster-tile-query/tarball/master",
     "spritezero": "https://github.com/mapbox/spritezero/tarball/master",
-    "mapbox-upload-validate": "https://github.com/mapbox/mapbox-upload-validate/tarball/master"
+    "mapbox-upload-validate": "https://github.com/mapbox/mapbox-upload-validate/tarball/update-deps"
   }, 
   "devDependencies": {
     "mocha": "1.x"


### PR DESCRIPTION
Tests all mapnik dependents with the `v2_spec` branch of node-mapnik (https://github.com/mapnik/node-mapnik/pull/579).

Current status: **18 passing, 5 failing**
- [x] **tilelive-bridge** is failing due to multiple references to `vt.isSolid` in [index.js] - (https://github.com/mapbox/tilelive-bridge/blob/master/index.js#L189).
  - https://github.com/mapbox/tilelive-bridge/pull/76
- [x] **vector-tile-query** is failing due to reference to `vt.parse` in [index.js](https://github.com/mapbox/vector-tile-query/blob/master/index.js#L152)
  - https://github.com/mapbox/vector-tile-query/pull/74
- [x] **tilelive-vector** is failing due to changes in the interface for `vt.addImage` in [backend.js](https://github.com/mapbox/tilelive-vector/blob/master/backend.js#L158)
  - https://github.com/mapbox/tilelive-vector/pull/118
- [x] **tilelive-omnivore** is failing due to `tilelive-bridge`'s failure (see above)
  - https://github.com/mapbox/tilelive-omnivore/pull/25
- [x] **mapbox-upload-validate** is failing in a way that I'm not sure about, but seems to involve de-serializing a serialtile with `tilelive.deserialize()`
  - https://github.com/mapbox/mapbox-upload-validate/pull/50
- [x] **mapbox-studio-classic** - https://github.com/mapbox/mapbox-studio-classic/pull/1530

cc/ @springmeyer @mapsam @flippmoke 