### PR TITLE
Node Mapnik Upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./test.js",
   "dependencies": {
-    "mapnik" : "https://github.com/mapnik/node-mapnik/tarball/master",
+    "mapnik" : "https://github.com/mapnik/node-mapnik/tarball/upgrade-opt-in",
     "srs":"~1.1.0",
     "gdal":"~0.8.0",
     "preprocessorcerer": "https://github.com/mapbox/preprocessorcerer/tarball/master",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "vector-tile-query": "https://github.com/mapbox/vector-tile-query/tarball/master",
     "assert-http": "https://github.com/mapbox/assert-http/tarball/master",
     "landspeed": "https://github.com/mapbox/landspeed.js/tarball/master",
-    "tilelive-vector": "https://github.com/mapbox/tilelive-vector/tarball/master",
+    "tilelive-vector": "https://github.com/mapbox/tilelive-vector/tarball/more-test-fixes",
     "mapnik-pool": "https://github.com/mapbox/mapnik-pool/tarball/master",
     "geojson-mapnikify": "https://github.com/mapbox/geojson-mapnikify/tarball/master",
     "tilelive-overlay": "https://github.com/mapbox/tilelive-overlay/tarball/master",


### PR DESCRIPTION
In preparation for the Node Mapnik `3.5.9` 🎤 drop.

cc @springmeyer @flippmoke @GretaCB @jakepruitt 
